### PR TITLE
Fix an issue with race result sorting when points are tied

### DIFF
--- a/FormuleCirkelEntity/Controllers/RacesController.cs
+++ b/FormuleCirkelEntity/Controllers/RacesController.cs
@@ -160,9 +160,10 @@ namespace FormuleCirkelEntity.Controllers
                     result.Status = Status.DNF;
             }
 
-            var orderedResults = race.DriverResults.OrderByDescending(d => d.Points).ToList();
-            foreach (var result in orderedResults)
-                result.Position = orderedResults.IndexOf(result) + 1;
+            var positionsList = _resultGenerator.GetPositionsBasedOnRelativePoints(race.DriverResults);
+
+            foreach (var result in race.DriverResults)
+                result.Position = positionsList[result.DriverResultId];
 
             _context.UpdateRange(race.DriverResults);
             await _context.SaveChangesAsync();
@@ -180,7 +181,7 @@ namespace FormuleCirkelEntity.Controllers
         }
 
         [HttpPost]
-        public IActionResult FinishRace (int seasonId, int raceId)
+        public IActionResult FinishRace(int seasonId, int raceId)
         {
             // Finishes the race, gives out points and returns to the Detail screen
             var raceresults = _context.DriverResults.Where(r => r.RaceId == raceId);
@@ -375,6 +376,7 @@ namespace FormuleCirkelEntity.Controllers
                 }
 
                 driver.Grid = result.Position.Value;
+                driver.Position = result.Position.Value;
             }
             _context.UpdateRange(driverResults);
             _context.SaveChanges();

--- a/FormuleCirkelEntity/ResultGenerators/RaceResultGenerator.cs
+++ b/FormuleCirkelEntity/ResultGenerators/RaceResultGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using FormuleCirkelEntity.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace FormuleCirkelEntity.ResultGenerators
@@ -92,6 +93,22 @@ namespace FormuleCirkelEntity.ResultGenerators
             result += driver.SeasonTeam.Chassis;
             result += _rng.Next(0, 60);
             return result;
+        }
+
+        /// <summary>
+        /// Get a dictionary of the results' position values based on their points total relative to each other.
+        /// </summary>
+        /// <param name="driverResults">The <see cref="DriverResult"/>s to determine the relative positions of.</param>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> of the driverResult ID's and the corresponding positions.</returns>
+        /// <remarks>When two driver points totals are equal, their position is determined based on their original grid position.</remarks>
+        public IDictionary<int, int> GetPositionsBasedOnRelativePoints(IEnumerable<DriverResult> driverResults)
+        {
+            var orderedResults = driverResults
+                .OrderByDescending(d => d.Points)
+                .ThenBy(d => d.Grid)
+                .ToList();
+
+            return orderedResults.ToDictionary((res => res.DriverResultId), (res => orderedResults.IndexOf(res) + 1));
         }
     }
 }

--- a/FormuleCirkelEntity/Views/Races/Race.cshtml
+++ b/FormuleCirkelEntity/Views/Races/Race.cshtml
@@ -21,7 +21,7 @@
     <table id="results" class="table table-sm">
         <thead>
             <tr>
-                <th>Pos.</th>
+                <th data-field="position">Pos.</th>
                 <th>Nr.</th>
                 <th>Naam</th>
                 <th>Team</th>
@@ -34,7 +34,7 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var driverResult in Model.DriverResults.OrderByDescending(d => d.Points))
+            @foreach (var driverResult in Model.DriverResults.OrderBy(d => d.Position))
             {
             <tr data-obj-id="@driverResult.SeasonDriverId">
                 <td data-field="position">@driverResult.Position</td>
@@ -82,10 +82,10 @@
             });
         });
 
-        let th = table.querySelector("th[data-field='pointsTotal']")
+        let th = table.querySelector("th[data-field='position']")
         let tableRows = tableBody.querySelectorAll("tr:nth-child(n+1)")
         Array.from(tableRows)
-            .sort(tableComparer(Array.from(th.parentNode.children).indexOf(th), false))
+            .sort(tableComparer(Array.from(th.parentNode.children).indexOf(th), true))
             .forEach(tr => table.querySelector("tbody").appendChild(tr));
     }
 


### PR DESCRIPTION
- Update the Race Result sorting mechanism to use the Position value.
- Formalize position sorting based on both points total and grid position instead of leaving ties to the ID order.
- Set race positions when saving the qualifying position to ensure proper sorting at the start of the race.